### PR TITLE
Improve recipe suggestion tool wording and fix chat sequential actions

### DIFF
--- a/app/api/assistants/cooking/route.ts
+++ b/app/api/assistants/cooking/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: Request) {
   });
 
   const result = streamText({
-    model: openai("gpt-4.1-mini"),
+    model: openai("gpt-4.1", { parallelToolCalls: false }),
     system: prompt[0].content,
     maxSteps: 5,
     messages,

--- a/app/api/assistants/cooking/route.ts
+++ b/app/api/assistants/cooking/route.ts
@@ -1,43 +1,43 @@
-import { openai } from '@ai-sdk/openai'
-import { streamText } from 'ai'
-import { updatePlannedMealTool } from '@/lib/ai/tools/tools'
-import { getPrompt } from '@/lib/ai/prompts'
-import { validateAssistantsRequest } from '@/app/api/assistants/validate-assistant-request'
+import { openai } from "@ai-sdk/openai";
+import { streamText } from "ai";
+import { updatePlannedMealTool } from "@/lib/ai/tools/tools";
+import { getPrompt } from "@/lib/ai/prompts";
+import { validateAssistantsRequest } from "@/app/api/assistants/validate-assistant-request";
 
 // Allow streaming responses up to 30 seconds
-export const maxDuration = 30
+export const maxDuration = 30;
 
 export async function POST(req: Request) {
-  const { messages, plannedMealWithRecipe } = await req.json()
+  const { messages, plannedMealWithRecipe } = await req.json();
 
-  const { error } = await validateAssistantsRequest(messages)
+  const { error } = await validateAssistantsRequest(messages);
   if (error) {
-    return error
+    return error;
   }
 
   if (!plannedMealWithRecipe) {
-    return new Response('Invalid payload: plannedMealWithRecipe is required', {
+    return new Response("Invalid payload: plannedMealWithRecipe is required", {
       status: 400,
-    })
+    });
   }
 
   const prompt = await getPrompt({
-    promptName: 'cooking-assistant',
+    promptName: "cooking-assistant",
     promptVars: {
       date: new Date().toISOString(),
       plannedMealWithRecipe: JSON.stringify(plannedMealWithRecipe),
     },
-  })
+  });
 
   const result = streamText({
-    model: openai('gpt-4.1-mini'),
+    model: openai("gpt-4.1-mini"),
     system: prompt[0].content,
     maxSteps: 5,
     messages,
     tools: {
       updatePlannedMealTool: updatePlannedMealTool,
     },
-  })
+  });
 
-  return result.toDataStreamResponse()
+  return result.toDataStreamResponse();
 }

--- a/app/api/assistants/planned-meal/route.ts
+++ b/app/api/assistants/planned-meal/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: Request) {
   });
 
   const result = streamText({
-    model: openai("gpt-4.1-mini"),
+    model: openai("gpt-4.1", { parallelToolCalls: false }),
     system: prompt[0].content,
     maxSteps: 5,
     messages,

--- a/app/api/assistants/planned-meal/route.ts
+++ b/app/api/assistants/planned-meal/route.ts
@@ -1,43 +1,43 @@
-import { openai } from '@ai-sdk/openai'
-import { streamText } from 'ai'
-import { updatePlannedMealTool } from '@/lib/ai/tools/tools'
-import { getPrompt } from '@/lib/ai/prompts'
-import { validateAssistantsRequest } from '@/app/api/assistants/validate-assistant-request'
+import { openai } from "@ai-sdk/openai";
+import { streamText } from "ai";
+import { updatePlannedMealTool } from "@/lib/ai/tools/tools";
+import { getPrompt } from "@/lib/ai/prompts";
+import { validateAssistantsRequest } from "@/app/api/assistants/validate-assistant-request";
 
 // Allow streaming responses up to 30 seconds
-export const maxDuration = 30
+export const maxDuration = 30;
 
 export async function POST(req: Request) {
-  const { messages, plannedMeal } = await req.json()
+  const { messages, plannedMeal } = await req.json();
 
-  const { error } = await validateAssistantsRequest(messages)
+  const { error } = await validateAssistantsRequest(messages);
   if (error) {
-    return error
+    return error;
   }
 
   if (!plannedMeal) {
-    return new Response('Invalid payload: plannedMeal is required', {
+    return new Response("Invalid payload: plannedMeal is required", {
       status: 400,
-    })
+    });
   }
 
   const prompt = await getPrompt({
-    promptName: 'planned-meal-assistant',
+    promptName: "planned-meal-assistant",
     promptVars: {
       date: new Date().toISOString(),
       plannedMeal: JSON.stringify(plannedMeal),
     },
-  })
+  });
 
   const result = streamText({
-    model: openai('gpt-4.1-mini'),
+    model: openai("gpt-4.1-mini"),
     system: prompt[0].content,
     maxSteps: 5,
     messages,
     tools: {
       updatePlannedMealTool: updatePlannedMealTool,
     },
-  })
+  });
 
-  return result.toDataStreamResponse()
+  return result.toDataStreamResponse();
 }

--- a/app/api/assistants/planning/route.ts
+++ b/app/api/assistants/planning/route.ts
@@ -35,7 +35,7 @@ export async function POST(req: Request) {
   });
 
   const result = streamText({
-    model: openai("gpt-4.1-mini"),
+    model: openai("gpt-4.1", { parallelToolCalls: false }),
     system: prompt[0].content,
     maxSteps: 5,
     messages,

--- a/app/api/assistants/recipe/route.ts
+++ b/app/api/assistants/recipe/route.ts
@@ -30,7 +30,9 @@ export async function POST(req: Request) {
   });
 
   const result = streamText({
-    model: openai("gpt-4.1-mini"),
+    model: openai("gpt-4.1", {
+      parallelToolCalls: false,
+    }),
     system: prompt[0].content,
     maxSteps: 5,
     messages,

--- a/app/api/assistants/recipe/route.ts
+++ b/app/api/assistants/recipe/route.ts
@@ -1,36 +1,36 @@
-import { openai } from '@ai-sdk/openai'
-import { streamText } from 'ai'
-import { deleteRecipeTool, updateRecipeTool } from '@/lib/ai/tools/tools'
-import { getPrompt } from '@/lib/ai/prompts'
-import { validateAssistantsRequest } from '@/app/api/assistants/validate-assistant-request'
+import { openai } from "@ai-sdk/openai";
+import { streamText } from "ai";
+import { deleteRecipeTool, updateRecipeTool } from "@/lib/ai/tools/tools";
+import { getPrompt } from "@/lib/ai/prompts";
+import { validateAssistantsRequest } from "@/app/api/assistants/validate-assistant-request";
 
 // Allow streaming responses up to 30 seconds
-export const maxDuration = 30
+export const maxDuration = 30;
 
 export async function POST(req: Request) {
-  const { messages, recipe } = await req.json()
+  const { messages, recipe } = await req.json();
 
-  const { error } = await validateAssistantsRequest(messages)
+  const { error } = await validateAssistantsRequest(messages);
   if (error) {
-    return error
+    return error;
   }
 
   if (!recipe) {
-    return new Response('Invalid payload: recipe is required', {
+    return new Response("Invalid payload: recipe is required", {
       status: 400,
-    })
+    });
   }
 
   const prompt = await getPrompt({
-    promptName: 'recipe-assistant',
+    promptName: "recipe-assistant",
     promptVars: {
       date: new Date().toISOString(),
       recipe: JSON.stringify(recipe),
     },
-  })
+  });
 
   const result = streamText({
-    model: openai('gpt-4.1-mini'),
+    model: openai("gpt-4.1-mini"),
     system: prompt[0].content,
     maxSteps: 5,
     messages,
@@ -49,7 +49,7 @@ export async function POST(req: Request) {
         execute: undefined,
       },
     },
-  })
+  });
 
-  return result.toDataStreamResponse()
+  return result.toDataStreamResponse();
 }

--- a/app/api/planned-meal/[id]/route.ts
+++ b/app/api/planned-meal/[id]/route.ts
@@ -15,8 +15,18 @@ export async function GET(
     //Auth is done in the action
     const plannedMeal = await getPlannedMealByIdAction(id)
     return NextResponse.json(plannedMeal)
-  } catch {
-    // TODO better error handling with custom error classes and status codes
+  } catch (error) {
+    // Handle planned meal not found vs other errors
+    if (error instanceof Error && error.message.includes('not found')) {
+      return NextResponse.json(
+        { error: 'Planned meal not found' },
+        { status: 404 }
+      )
+    }
+    
+    // Log the actual error for debugging
+    console.error('[API] /api/planned-meal/[id] GET error:', error)
+    
     return NextResponse.json(
       { error: 'Internal Server Error' },
       { status: 500 }
@@ -66,8 +76,18 @@ export async function DELETE(
   try {
     await deletePlannedMealAction(id)
     return NextResponse.json({ success: true })
-  } catch {
-    // TODO better error handling with custom error classes and status codes
+  } catch (error) {
+    // Handle planned meal not found vs other errors
+    if (error instanceof Error && error.message.includes('Planned meal not found')) {
+      return NextResponse.json(
+        { error: 'Planned meal not found' },
+        { status: 404 }
+      )
+    }
+    
+    // Log the actual error for debugging
+    console.error('[API] /api/planned-meal/[id] DELETE error:', error)
+    
     return NextResponse.json(
       { error: 'Internal Server Error' },
       { status: 500 }

--- a/app/api/recipe/[id]/route.ts
+++ b/app/api/recipe/[id]/route.ts
@@ -10,8 +10,18 @@ export async function GET(
     //Auth is done in the action
     const recipe = await getRecipeByIdAction(id)
     return NextResponse.json(recipe)
-  } catch {
-    // TODO better error handling with custom error classes and status codes
+  } catch (error) {
+    // Handle recipe not found vs other errors
+    if (error instanceof Error && error.message.includes('Recipe not found')) {
+      return NextResponse.json(
+        { error: 'Recipe not found' },
+        { status: 404 }
+      )
+    }
+    
+    // Log the actual error for debugging
+    console.error('[API] /api/recipe/[id] GET error:', error)
+    
     return NextResponse.json(
       { error: 'Internal Server Error' },
       { status: 500 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,10 +28,10 @@ export default function Home() {
       ],
       // run client-side tools that are automatically executed:
       async onToolCall({ toolCall }) {
-        if (toolCall.toolName === 'renderRecipePreviewTool') {
+        if (toolCall.toolName === 'renderRecipeSuggestionTool') {
           return {
             success: true,
-            data: 'The recipe was successfully rendered',
+            data: 'The recipe suggestion was successfully rendered',
           } as ToolResult<string>
         }
         if (toolCall.toolName === 'enterCookingModeTool') {

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -1,18 +1,18 @@
-import { ChatInput } from './chat-input'
-import { ChatMessagesDisplay } from './chat-messages-display'
+import { ChatInput } from "./chat-input";
+import { ChatMessagesDisplay } from "./chat-messages-display";
 
-import { Message } from 'ai'
-import { ChatSuggestions } from './chat-suggestions'
-import { ChatSuggestion } from '@/lib/types'
+import { Message } from "ai";
+import { ChatSuggestions } from "./chat-suggestions";
+import { ChatSuggestion } from "@/lib/types";
 
 interface ChatProps {
-  messages: Message[]
-  input: string
-  handleInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
-  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void
-  error?: Error | undefined
-  suggestions?: ChatSuggestion[]
-  handleSuggestionClick?: (suggestion: ChatSuggestion) => void
+  messages: Message[];
+  input: string;
+  handleInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  error?: Error | undefined;
+  suggestions?: ChatSuggestion[];
+  handleSuggestionClick?: (suggestion: ChatSuggestion) => void;
 }
 
 export function Chat({
@@ -46,5 +46,5 @@ export function Chat({
         />
       </div>
     </div>
-  )
+  );
 }

--- a/components/cooking/cooking-view.tsx
+++ b/components/cooking/cooking-view.tsx
@@ -1,29 +1,29 @@
-'use client'
+"use client";
 
-import { RecipeViewer } from '@/components/recipes/recipe-viewer'
-import { Button } from '@/components/ui/button'
-import { Check } from 'lucide-react'
-import { useRouter } from 'next/navigation'
-import { toast } from 'sonner'
-import { PlannedMealWithRecipe } from '@/lib/types'
-import { useUpdatePlannedMealStatusMutation } from '@/lib/api/hooks/planned-meals'
-import { triggerToolEffects } from '@/lib/ai/tools/effects'
-import { useQueryClient } from '@tanstack/react-query'
-import { PlannedMealStatus } from '@prisma/client'
-import { CookingCongratulationsDialog } from '@/components/cooking/cooking-congratulations-dialog'
-import { ToolResult } from '@/lib/ai/tools/types'
-import { ChatCanva } from '@/components/chat/chat-canva'
-import { plannedMealToRecipe } from '@/lib/utils/plannedMealUtils'
-import { UseChatOptions } from '@ai-sdk/react'
-import { apiRoutes } from '@/lib/api/api-routes'
-import { routes } from '@/lib/routes'
+import { RecipeViewer } from "@/components/recipes/recipe-viewer";
+import { Button } from "@/components/ui/button";
+import { Check } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { PlannedMealWithRecipe } from "@/lib/types";
+import { useUpdatePlannedMealStatusMutation } from "@/lib/api/hooks/planned-meals";
+import { triggerToolEffects } from "@/lib/ai/tools/effects";
+import { useQueryClient } from "@tanstack/react-query";
+import { PlannedMealStatus } from "@prisma/client";
+import { CookingCongratulationsDialog } from "@/components/cooking/cooking-congratulations-dialog";
+import { ToolResult } from "@/lib/ai/tools/types";
+import { ChatCanva } from "@/components/chat/chat-canva";
+import { plannedMealToRecipe } from "@/lib/utils/plannedMealUtils";
+import { UseChatOptions } from "@ai-sdk/react";
+import { apiRoutes } from "@/lib/api/api-routes";
+import { routes } from "@/lib/routes";
 interface CookingViewProps {
-  plannedMealWithRecipe: PlannedMealWithRecipe
+  plannedMealWithRecipe: PlannedMealWithRecipe;
 }
 
 export function CookingView({ plannedMealWithRecipe }: CookingViewProps) {
-  const queryClient = useQueryClient()
-  const router = useRouter()
+  const queryClient = useQueryClient();
+  const router = useRouter();
 
   const chatOptions: UseChatOptions = {
     api: apiRoutes.assistants.cooking,
@@ -32,54 +32,54 @@ export function CookingView({ plannedMealWithRecipe }: CookingViewProps) {
     },
     initialMessages: [
       {
-        id: 'cooking-intro',
+        id: "cooking-intro",
         content: `I'll guide you through cooking ${
           plannedMealWithRecipe.overrideName ||
           plannedMealWithRecipe.recipe.name
         }. Let me know if you have questions at any step or want to make changes!`,
-        role: 'assistant',
+        role: "assistant",
       },
     ],
     // run client-side tools that are automatically executed:
     async onToolCall({ toolCall }) {
-      if (toolCall.toolName === 'renderRecipePreviewTool') {
+      if (toolCall.toolName === "renderRecipeSuggestionTool") {
         return {
           success: true,
-          data: 'The recipe was successfully rendered',
-        } as ToolResult<string>
+          data: "The recipe was successfully rendered",
+        } as ToolResult<string>;
       }
     },
     onFinish: (message) => {
       // client-side side effects such as cache invalidation
-      triggerToolEffects(message, queryClient)
+      triggerToolEffects(message, queryClient);
     },
-  }
+  };
 
   const updateCookingStatusMutation = useUpdatePlannedMealStatusMutation({
     options: {
       onError: () => {
-        toast.error('Failed to update cooking status.')
+        toast.error("Failed to update cooking status.");
       },
     },
-  })
+  });
   const handleMarkUncooked = () => {
     updateCookingStatusMutation.mutate({
       id: plannedMealWithRecipe.id,
       status: PlannedMealStatus.PLANNED,
-    })
-  }
+    });
+  };
   const handleMarkCooked = () => {
     updateCookingStatusMutation.mutate({
       id: plannedMealWithRecipe.id,
       status: PlannedMealStatus.COOKED,
-    })
-  }
+    });
+  };
   const handleGoHome = () => {
-    router.push(routes.home)
-  }
+    router.push(routes.home);
+  };
 
   // Get the effective recipe data (with overrides)
-  const effectiveRecipe = plannedMealToRecipe(plannedMealWithRecipe)
+  const effectiveRecipe = plannedMealToRecipe(plannedMealWithRecipe);
 
   const markAsCookedButton = (
     <Button
@@ -91,7 +91,7 @@ export function CookingView({ plannedMealWithRecipe }: CookingViewProps) {
       <Check className="h-4 w-4" />
       <span className="hidden sm:inline">Mark as cooked</span>
     </Button>
-  )
+  );
   return (
     <div className="flex flex-col h-full">
       {/* Congratulations Dialog: This is a modal that appears when the meal is cooked */}
@@ -113,5 +113,5 @@ export function CookingView({ plannedMealWithRecipe }: CookingViewProps) {
         actions={markAsCookedButton}
       />
     </div>
-  )
+  );
 }

--- a/components/planned-meals/planned-meal-chat-view.tsx
+++ b/components/planned-meals/planned-meal-chat-view.tsx
@@ -27,7 +27,8 @@ export function PlannedMealChatView({ plannedMeal }: PlannedMealChatViewProps) {
     id: plannedMeal.id,
     options: {
       onSuccess: () => {
-        router.push(routes.plannedMeal.all)
+        // Use replace instead of push to prevent back navigation to deleted planned meal
+        router.replace(routes.plannedMeal.all)
       },
     },
   })

--- a/components/recipes/recipe-chat-view.tsx
+++ b/components/recipes/recipe-chat-view.tsx
@@ -26,7 +26,8 @@ export function RecipeChatView({ recipe }: RecipeChatViewProps) {
     id: recipe.id,
     options: {
       onSuccess: () => {
-        router.push(routes.recipes.all)
+        // Use replace instead of push to prevent back navigation to deleted recipe
+        router.replace(routes.recipes.all)
       },
     },
   })

--- a/components/recipes/recipe-suggestion-card.tsx
+++ b/components/recipes/recipe-suggestion-card.tsx
@@ -4,17 +4,17 @@ import {
   CardTitle,
   CardHeader,
   CardDescription,
-} from '@/components/ui/card'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { CreateRecipeInput } from '@/lib/validators/recipe'
-import { MemoizedMarkdown } from '@/components/chat/memoized-markdown'
-import { RecipeMetadataDescription } from './shared/recipe-card-base'
-export const RecipePreviewCard = ({
+} from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CreateRecipeInput } from "@/lib/validators/recipe";
+import { MemoizedMarkdown } from "@/components/chat/memoized-markdown";
+import { RecipeMetadataDescription } from "./shared/recipe-card-base";
+export const RecipeSuggestionCard = ({
   cardData,
   id,
 }: {
-  cardData: CreateRecipeInput
-  id: string
+  cardData: CreateRecipeInput;
+  id: string;
 }) => {
   return (
     <Card className="w-full mx-auto overflow-hidden shadow-sm">
@@ -61,5 +61,5 @@ export const RecipePreviewCard = ({
         </Tabs>
       </CardContent>
     </Card>
-  )
-}
+  );
+};

--- a/lib/ai/tools/definitions.ts
+++ b/lib/ai/tools/definitions.ts
@@ -8,7 +8,11 @@ import {
   updatePlannedMealInputSchema,
 } from "@/lib/validators/plannedMeals";
 import { defineTool } from "@/lib/ai/tools/types";
-import { RecipeMetadata, PlannedMealMetadata, asTypedSchema } from "@/lib/types";
+import {
+  RecipeMetadata,
+  PlannedMealMetadata,
+  asTypedSchema,
+} from "@/lib/types";
 import { Recipe, PlannedMeal } from "@prisma/client";
 
 export const getRecipesMetadataDefinition = defineTool({
@@ -18,13 +22,15 @@ export const getRecipesMetadataDefinition = defineTool({
 });
 
 export const getPlannedMealsMetadataDefinition = defineTool({
-  description: "Get the metadata of all planned meals with status PLANNED belonging to the user.",
+  description:
+    "Get the metadata of all planned meals with status PLANNED belonging to the user.",
   parameters: z.object({}),
   result: asTypedSchema<PlannedMealMetadata[]>(),
 });
 
 export const getPlannedMealsDefinition = defineTool({
-  description: "Get all planned meals with status PLANNED belonging to the user. Useful for fetching all ingredients of upcoming meals.",
+  description:
+    "Get all planned meals with status PLANNED belonging to the user. Useful for fetching all ingredients of upcoming meals.",
   parameters: z.object({}),
   result: asTypedSchema<PlannedMeal[]>(),
 });
@@ -85,8 +91,9 @@ export const deletePlannedMealDefinition = defineTool({
   result: asTypedSchema<string>(),
 });
 
-export const renderRecipePreviewDefinition = defineTool({
-  description: "Renders a preview of a full recipe.",
+export const renderRecipeSuggestionDefinition = defineTool({
+  description:
+    "Renders a suggestion for a recipe without creating it. Use this to show users recipe ideas they can choose to create later. You can create any number and make multiple suggestions in a row.",
   parameters: createRecipeInputSchema,
   result: asTypedSchema<string>(),
 });

--- a/lib/ai/tools/renderer.tsx
+++ b/lib/ai/tools/renderer.tsx
@@ -1,75 +1,75 @@
-import React from 'react'
-import { RecipePreviewCard } from '@/components/recipes/recipe-preview-card'
-import { ToolInvocation } from 'ai'
+import React from "react";
+import { RecipeSuggestionCard } from "@/components/recipes/recipe-suggestion-card";
+import { ToolInvocation } from "ai";
 import {
   ToolSuccess,
   ToolSpinner,
   ToolError,
-} from '@/components/chat/tool-feedback'
-import { PlannedMealMetadata, RecipeMetadata } from '@/lib/types'
-import { PlannedMeal, Recipe } from '@prisma/client'
-import { ToolResult } from '@/lib/ai/tools/types'
+} from "@/components/chat/tool-feedback";
+import { PlannedMealMetadata, RecipeMetadata } from "@/lib/types";
+import { PlannedMeal, Recipe } from "@prisma/client";
+import { ToolResult } from "@/lib/ai/tools/types";
 
 // Simple type for tool rendering functions
-type ToolRenderer = (toolInvocation: ToolInvocation) => React.ReactNode
+type ToolRenderer = (toolInvocation: ToolInvocation) => React.ReactNode;
 
 // Map of tool names to their rendering functions
-const toolRenderers: Record<string, ToolRenderer> = {}
+const toolRenderers: Record<string, ToolRenderer> = {};
 
 // Simple function to render a tool's output
 export function renderToolInvocation(
   toolInvocation: ToolInvocation
 ): React.ReactNode {
-  const renderer = toolRenderers[toolInvocation.toolName]
+  const renderer = toolRenderers[toolInvocation.toolName];
   if (!renderer)
     return (
       <ToolError
         message={`No renderer found for tool: ${toolInvocation.toolName}`}
       />
-    )
+    );
 
-  return renderer(toolInvocation)
+  return renderer(toolInvocation);
 }
 
 // A simple tool renderer that renders a message for loading and success states
 function toolMessageRenderer<T>({
   loadingMessage,
   successMessage,
-  errorMessage = (error: Extract<ToolResult<T>, { success: false }>['error']) =>
+  errorMessage = (error: Extract<ToolResult<T>, { success: false }>["error"]) =>
     error,
 }: {
-  loadingMessage: string
+  loadingMessage: string;
   successMessage: (
-    data: Extract<ToolResult<T>, { success: true }>['data']
-  ) => string
+    data: Extract<ToolResult<T>, { success: true }>["data"]
+  ) => string;
   errorMessage?: (
-    error: Extract<ToolResult<T>, { success: false }>['error']
-  ) => string
+    error: Extract<ToolResult<T>, { success: false }>["error"]
+  ) => string;
 }): (toolInvocation: ToolInvocation) => React.ReactNode {
   const renderer = (toolInvocation: ToolInvocation) => {
     switch (toolInvocation.state) {
-      case 'partial-call':
-        return <ToolSpinner message={loadingMessage} />
-      case 'call':
-        return <ToolSpinner message={loadingMessage} />
-      case 'result':
+      case "partial-call":
+        return <ToolSpinner message={loadingMessage} />;
+      case "call":
+        return <ToolSpinner message={loadingMessage} />;
+      case "result":
         if (!toolInvocation.result.success) {
           return (
             <ToolError message={errorMessage(toolInvocation.result.error)} />
-          )
+          );
         }
         return (
           <ToolSuccess message={successMessage(toolInvocation.result.data)} />
-        )
+        );
       default:
-        return <ToolError message="Unknown tool state" />
+        return <ToolError message="Unknown tool state" />;
     }
-  }
+  };
 
   // Add display name to fix ESLint warning
-  renderer.displayName = 'ToolMessageRenderer'
+  renderer.displayName = "ToolMessageRenderer";
 
-  return renderer
+  return renderer;
 }
 
 // TODO in all functions below, tighter typing for result.data => should be linked to the actual tool
@@ -77,8 +77,8 @@ function toolMessageRenderer<T>({
 const renderGetRecipesMetadataTool = toolMessageRenderer<RecipeMetadata[]>({
   loadingMessage: `Retrieving recipes metadata...`,
   successMessage: (data) =>
-    `Retrieved ${data.length} recipe${data.length > 1 ? 's' : ''} metadata!`,
-})
+    `Retrieved ${data.length} recipe${data.length > 1 ? "s" : ""} metadata!`,
+});
 
 const renderGetPlannedMealsMetadataTool = toolMessageRenderer<
   PlannedMealMetadata[]
@@ -86,89 +86,90 @@ const renderGetPlannedMealsMetadataTool = toolMessageRenderer<
   loadingMessage: `Retrieving planned meals metadata...`,
   successMessage: (data) =>
     `Retrieved ${data.length} planned meal${
-      data.length > 1 ? 's' : ''
+      data.length > 1 ? "s" : ""
     } metadata!`,
-})
+});
 
 const renderGetPlannedMealsTool = toolMessageRenderer<PlannedMealMetadata[]>({
   loadingMessage: `Retrieving planned meals...`,
   successMessage: (data) =>
-    `Retrieved ${data.length} planned meal${data.length > 1 ? 's' : ''}!`,
-})
+    `Retrieved ${data.length} planned meal${data.length > 1 ? "s" : ""}!`,
+});
 
 const renderCreateRecipeTool = toolMessageRenderer<Recipe>({
-  loadingMessage: 'Creating recipe...',
+  loadingMessage: "Creating recipe...",
   successMessage: (data) => `Recipe "${data.name}" created successfully!`,
-})
+});
 
 const renderCreatePlannedMealTool = toolMessageRenderer<PlannedMeal>({
-  loadingMessage: 'Planning recipe...',
-  successMessage: () => 'Recipe planned successfully!',
-})
+  loadingMessage: "Planning recipe...",
+  successMessage: () => "Recipe planned successfully!",
+});
 
 const renderDeleteRecipeTool = toolMessageRenderer<Recipe>({
-  loadingMessage: 'Deleting recipe...',
-  successMessage: () => 'Recipe deleted successfully!',
-})
+  loadingMessage: "Deleting recipe...",
+  successMessage: () => "Recipe deleted successfully!",
+});
 
 const renderDeletePlannedMealTool = toolMessageRenderer<PlannedMeal>({
-  loadingMessage: 'Deleting planned meal...',
-  successMessage: () => 'Planned meal deleted successfully!',
-})
+  loadingMessage: "Deleting planned meal...",
+  successMessage: () => "Planned meal deleted successfully!",
+});
 
 const renderUpdateRecipeTool = toolMessageRenderer<Recipe>({
-  loadingMessage: 'Updating recipe...',
-  successMessage: () => 'Recipe updated successfully!',
-})
+  loadingMessage: "Updating recipe...",
+  successMessage: () => "Recipe updated successfully!",
+});
 
 const renderUpdatePlannedMealTool = toolMessageRenderer<PlannedMeal>({
-  loadingMessage: 'Updating planned meal...',
-  successMessage: () => 'Planned meal updated successfully!',
-})
+  loadingMessage: "Updating planned meal...",
+  successMessage: () => "Planned meal updated successfully!",
+});
 
 const renderGetRecipeByIdTool = toolMessageRenderer<Recipe>({
-  loadingMessage: 'Retrieving recipe...',
-  successMessage: () => 'Recipe retrieved successfully!',
-})
+  loadingMessage: "Retrieving recipe...",
+  successMessage: () => "Recipe retrieved successfully!",
+});
 
 const renderGetPlannedMealByIdTool = toolMessageRenderer<PlannedMeal>({
-  loadingMessage: 'Retrieving planned meal...',
-  successMessage: () => 'Planned meal retrieved successfully!',
-})
+  loadingMessage: "Retrieving planned meal...",
+  successMessage: () => "Planned meal retrieved successfully!",
+});
 
 const renderEnterCookingModeTool = toolMessageRenderer<void>({
-  loadingMessage: 'Entering cooking mode...',
-  successMessage: () => 'Cooking mode entered successfully!',
-})
+  loadingMessage: "Entering cooking mode...",
+  successMessage: () => "Cooking mode entered successfully!",
+});
 
-function renderRecipePreviewTool(
+function renderRecipeSuggestionTool(
   toolInvocation: ToolInvocation
 ): React.ReactNode {
   switch (toolInvocation.state) {
-    case 'partial-call':
-      return <ToolSpinner message={`Rendering recipe preview...`} />
-    case 'call':
-      return <ToolSpinner message={`Rendering recipe preview...`} />
-    case 'result':
+    case "partial-call":
+      return <ToolSpinner message={`Generating recipe suggestion...`} />;
+    case "call":
+      return <ToolSpinner message={`Generating recipe suggestion...`} />;
+    case "result":
       return (
-        <RecipePreviewCard
+        <RecipeSuggestionCard
           cardData={toolInvocation.args}
           id={toolInvocation.toolCallId}
         />
-      )
+      );
   }
 }
 
-toolRenderers['renderRecipePreviewTool'] = renderRecipePreviewTool
-toolRenderers['createRecipeTool'] = renderCreateRecipeTool
-toolRenderers['deleteRecipeTool'] = renderDeleteRecipeTool
-toolRenderers['getRecipesMetadataTool'] = renderGetRecipesMetadataTool
-toolRenderers['updateRecipeTool'] = renderUpdateRecipeTool
-toolRenderers['getRecipeByIdTool'] = renderGetRecipeByIdTool
-toolRenderers['getPlannedMealsMetadataTool'] = renderGetPlannedMealsMetadataTool
-toolRenderers['getPlannedMealsTool'] = renderGetPlannedMealsTool
-toolRenderers['createPlannedMealTool'] = renderCreatePlannedMealTool
-toolRenderers['deletePlannedMealTool'] = renderDeletePlannedMealTool
-toolRenderers['updatePlannedMealTool'] = renderUpdatePlannedMealTool
-toolRenderers['getPlannedMealByIdTool'] = renderGetPlannedMealByIdTool
-toolRenderers['enterCookingModeTool'] = renderEnterCookingModeTool
+toolRenderers["renderRecipeSuggestionTool"] = renderRecipeSuggestionTool;
+toolRenderers["createRecipeTool"] = renderCreateRecipeTool;
+toolRenderers["deleteRecipeTool"] = renderDeleteRecipeTool;
+toolRenderers["getRecipesMetadataTool"] = renderGetRecipesMetadataTool;
+toolRenderers["updateRecipeTool"] = renderUpdateRecipeTool;
+toolRenderers["getRecipeByIdTool"] = renderGetRecipeByIdTool;
+toolRenderers["getPlannedMealsMetadataTool"] =
+  renderGetPlannedMealsMetadataTool;
+toolRenderers["getPlannedMealsTool"] = renderGetPlannedMealsTool;
+toolRenderers["createPlannedMealTool"] = renderCreatePlannedMealTool;
+toolRenderers["deletePlannedMealTool"] = renderDeletePlannedMealTool;
+toolRenderers["updatePlannedMealTool"] = renderUpdatePlannedMealTool;
+toolRenderers["getPlannedMealByIdTool"] = renderGetPlannedMealByIdTool;
+toolRenderers["enterCookingModeTool"] = renderEnterCookingModeTool;

--- a/lib/ai/tools/tools.ts
+++ b/lib/ai/tools/tools.ts
@@ -12,7 +12,7 @@ import {
   deletePlannedMealDefinition,
   getPlannedMealByIdDefinition,
   getPlannedMealsDefinition,
-  renderRecipePreviewDefinition,
+  renderRecipeSuggestionDefinition,
   enterCookingModeDefinition,
 } from '@/lib/ai/tools/definitions'
 
@@ -96,9 +96,9 @@ export const deletePlannedMealTool = tool({
   execute: deletePlannedMealExecute,
 })
 
-export const renderRecipePreviewTool = tool({
-  description: renderRecipePreviewDefinition.description,
-  parameters: renderRecipePreviewDefinition.parameters,
+export const renderRecipeSuggestionTool = tool({
+  description: renderRecipeSuggestionDefinition.description,
+  parameters: renderRecipeSuggestionDefinition.parameters,
   // client-side only
 })
 
@@ -120,6 +120,6 @@ export const tools = [
   updatePlannedMealTool,
   deleteRecipeTool,
   deletePlannedMealTool,
-  renderRecipePreviewTool,
+  renderRecipeSuggestionTool,
   enterCookingModeTool,
 ]

--- a/lib/api/fetchers.ts
+++ b/lib/api/fetchers.ts
@@ -15,6 +15,14 @@ export async function fetcher<T = unknown>(
 
   if (!res.ok) {
     const errorText = await res.text();
+    
+    // Handle 404 errors more gracefully - don't log these as they're often expected
+    if (res.status === 404) {
+      const error = new Error('Resource not found');
+      error.name = 'NotFoundError';
+      throw error;
+    }
+    
     handleApiError(errorText, url);
   }
 

--- a/lib/api/hooks/planned-meals.ts
+++ b/lib/api/hooks/planned-meals.ts
@@ -235,13 +235,19 @@ export const useDeletePlannedMealMutation = ({
       );
       options.onError?.(error, variables, context);
     },
+    onSuccess: (data, variables, context) => {
+      options.onSuccess?.(data, variables, context)
+      
+      // Remove the specific planned meal from cache instead of just invalidating
+      queryClient.removeQueries({
+        queryKey: queryKeys.plannedMeals.byId(id),
+      })
+      
+      queryClient.invalidateQueries({ queryKey: queryKeys.plannedMeals.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.recipes.all })
+    },
     onSettled: (data, error, variables, context) => {
       options.onSettled?.(data, error, variables, context);
-      queryClient.invalidateQueries({ queryKey: queryKeys.plannedMeals.all });
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.plannedMeals.byId(id),
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.recipes.all });
     },
   });
 };

--- a/lib/api/hooks/planned-meals.ts
+++ b/lib/api/hooks/planned-meals.ts
@@ -4,60 +4,60 @@ import {
   useQuery,
   useQueryClient,
   UseQueryOptions,
-} from '@tanstack/react-query'
-import { PlannedMealWithRecipe, PlannedMealMetadata } from '@/lib/types'
-import { PlannedMeal, PlannedMealStatus } from '@prisma/client'
+} from "@tanstack/react-query";
+import { PlannedMealWithRecipe, PlannedMealMetadata } from "@/lib/types";
+import { PlannedMeal, PlannedMealStatus } from "@prisma/client";
 import {
   getPlannedMealsMetadata,
   getPlannedMealWithRecipeById,
   updatePlannedMealStatus,
   updatePlannedMeal,
   deletePlannedMealById,
-} from '@/lib/api/client'
-import { queryKeys } from '@/lib/api/query-keys'
-import { UpdatePlannedMealInput } from '@/lib/validators/plannedMeals'
+} from "@/lib/api/client";
+import { queryKeys } from "@/lib/api/query-keys";
+import { UpdatePlannedMealInput } from "@/lib/validators/plannedMeals";
 
 export const usePlannedMealWithRecipe = ({
   id,
   options = {},
 }: {
-  id: string
+  id: string;
   options?: Omit<
     UseQueryOptions<PlannedMealWithRecipe, Error>,
-    'queryKey' | 'queryFn'
-  >
+    "queryKey" | "queryFn"
+  >;
 }) => {
   return useQuery({
     ...options,
     queryKey: queryKeys.plannedMeals.byId(id),
     queryFn: async () => await getPlannedMealWithRecipeById(id),
-  })
-}
+  });
+};
 
 export const usePlannedMealsMetadata = ({
   options = {},
 }: {
   options?: Omit<
     UseQueryOptions<PlannedMealMetadata[], Error>,
-    'queryKey' | 'queryFn'
-  >
+    "queryKey" | "queryFn"
+  >;
 } = {}) => {
   return useQuery({
     ...options,
     queryKey: queryKeys.plannedMeals.all,
     queryFn: async () => await getPlannedMealsMetadata(),
-  })
-}
+  });
+};
 
 type CookedStatusVars = {
-  id: string
-  status: PlannedMealStatus
-}
+  id: string;
+  status: PlannedMealStatus;
+};
 
 type StatusMutationContext = {
-  previousPlannedMeal: PlannedMealWithRecipe | undefined
-  previousPlannedMealsMetadata: PlannedMealMetadata[] | undefined
-}
+  previousPlannedMeal: PlannedMealWithRecipe | undefined;
+  previousPlannedMealsMetadata: PlannedMealMetadata[] | undefined;
+};
 
 export const useUpdatePlannedMealStatusMutation = ({
   options = {},
@@ -69,10 +69,10 @@ export const useUpdatePlannedMealStatusMutation = ({
       CookedStatusVars,
       StatusMutationContext
     >,
-    'mutationFn' | 'onMutate'
-  >
+    "mutationFn" | "onMutate"
+  >;
 } = {}) => {
-  const queryClient = useQueryClient()
+  const queryClient = useQueryClient();
 
   return useMutation({
     ...options,
@@ -81,19 +81,19 @@ export const useUpdatePlannedMealStatusMutation = ({
       // Cancel any outgoing refetches
       await queryClient.cancelQueries({
         queryKey: queryKeys.plannedMeals.byId(variables.id),
-      })
+      });
       await queryClient.cancelQueries({
         queryKey: queryKeys.plannedMeals.all,
-      })
+      });
 
       // Snapshot the previous values
       const previousPlannedMeal =
         queryClient.getQueryData<PlannedMealWithRecipe>(
           queryKeys.plannedMeals.byId(variables.id)
-        )
+        );
       const previousPlannedMealsMetadata = queryClient.getQueryData<
         PlannedMealMetadata[]
-      >(queryKeys.plannedMeals.all)
+      >(queryKeys.plannedMeals.all);
 
       // Optimistically update the cache
       queryClient.setQueryData(
@@ -105,7 +105,7 @@ export const useUpdatePlannedMealStatusMutation = ({
                 status: variables.status,
               }
             : undefined
-      )
+      );
       queryClient.setQueryData(
         queryKeys.plannedMeals.all,
         (old: PlannedMealMetadata[] | undefined) =>
@@ -116,82 +116,81 @@ export const useUpdatePlannedMealStatusMutation = ({
                   : meal
               )
             : undefined
-      )
+      );
 
       // Return the previous values to be used in onError
-      return { previousPlannedMeal, previousPlannedMealsMetadata }
+      return { previousPlannedMeal, previousPlannedMealsMetadata };
     },
     onError: (error, variables, context) => {
       // Rollback the previous state
-      console.log('onError', error, variables, context)
       queryClient.setQueryData(
         queryKeys.plannedMeals.byId(variables.id),
         context?.previousPlannedMeal
-      )
+      );
       queryClient.setQueryData(
         queryKeys.plannedMeals.all,
         context?.previousPlannedMealsMetadata
-      )
-      options.onError?.(error, variables, context)
+      );
+      options.onError?.(error, variables, context);
     },
     onSettled: (data, error, variables, context) => {
-      options.onSettled?.(data, error, variables, context)
-      queryClient.invalidateQueries({ queryKey: queryKeys.plannedMeals.all })
+      options.onSettled?.(data, error, variables, context);
+      queryClient.invalidateQueries({ queryKey: queryKeys.plannedMeals.all });
       queryClient.invalidateQueries({
         queryKey: queryKeys.plannedMeals.byId(variables.id),
-      })
+      });
       if (data?.recipeId) {
         queryClient.invalidateQueries({
           queryKey: queryKeys.recipes.byId(data.recipeId),
-        })
+        });
       }
-      options.onSettled?.(data, error, variables, context)
+      options.onSettled?.(data, error, variables, context);
     },
-  })
-}
+  });
+};
 
 export const useUpdatePlannedMealMutation = ({
   options = {},
 }: {
   options?: Omit<
     UseMutationOptions<PlannedMeal, Error, UpdatePlannedMealInput>,
-    'mutationFn'
-  >
+    "mutationFn"
+  >;
 } = {}) => {
-  const queryClient = useQueryClient()
+  const queryClient = useQueryClient();
   return useMutation({
     ...options,
     mutationFn: async (updateData: UpdatePlannedMealInput) => {
-      const updatedPlannedMeal = await updatePlannedMeal(updateData)
-      return updatedPlannedMeal
+      const updatedPlannedMeal = await updatePlannedMeal(updateData);
+      return updatedPlannedMeal;
     },
     onSuccess: (data, variables, context) => {
-      options.onSuccess?.(data, variables, context)
+      options.onSuccess?.(data, variables, context);
     },
     onError: (error, variables, context) => {
-      options.onError?.(error, variables, context)
+      options.onError?.(error, variables, context);
     },
     onSettled: (data, error, variables, context) => {
-      options.onSettled?.(data, error, variables, context)
-      queryClient.invalidateQueries({ queryKey: queryKeys.plannedMeals.all })
+      options.onSettled?.(data, error, variables, context);
+      queryClient.invalidateQueries({ queryKey: queryKeys.plannedMeals.all });
       queryClient.invalidateQueries({
         queryKey: queryKeys.plannedMeals.byId(variables.id),
-      })
+      });
     },
-  })
-}
+  });
+};
 
 export const useDeletePlannedMealMutation = ({
   id,
   options = {},
 }: {
-  id: string
+  id: string;
   options?: Omit<
     UseMutationOptions<{ success: boolean }, Error>,
-    'mutationFn' | 'onMutate'
-  >
+    "mutationFn" | "onMutate"
+  >;
 }) => {
-  const queryClient = useQueryClient()
+  const queryClient = useQueryClient();
   return useMutation({
     ...options,
     mutationFn: async () => await deletePlannedMealById(id),
@@ -199,50 +198,50 @@ export const useDeletePlannedMealMutation = ({
       // optimistic update for planned meals only
       await queryClient.cancelQueries({
         queryKey: queryKeys.plannedMeals.byId(id),
-      })
+      });
       await queryClient.cancelQueries({
         queryKey: queryKeys.plannedMeals.all,
-      })
+      });
 
       // snapshot the previous values
       const previousPlannedMeal =
         queryClient.getQueryData<PlannedMealWithRecipe>(
           queryKeys.plannedMeals.byId(id)
-        )
+        );
       const previousPlannedMealsMetadata = queryClient.getQueryData<
         PlannedMealMetadata[]
-      >(queryKeys.plannedMeals.all)
+      >(queryKeys.plannedMeals.all);
 
       // update the cache
-      queryClient.setQueryData(queryKeys.plannedMeals.byId(id), undefined)
+      queryClient.setQueryData(queryKeys.plannedMeals.byId(id), undefined);
       queryClient.setQueryData(
         queryKeys.plannedMeals.all,
         (old: PlannedMealMetadata[] | undefined) =>
           old?.filter((meal) => meal.id !== id)
-      )
+      );
 
       // return the previous values to be used in onError
-      return { previousPlannedMeal, previousPlannedMealsMetadata }
+      return { previousPlannedMeal, previousPlannedMealsMetadata };
     },
     onError: (error, variables, context) => {
       // rollback the previous state
       queryClient.setQueryData(
         queryKeys.plannedMeals.byId(id),
         context?.previousPlannedMeal
-      )
+      );
       queryClient.setQueryData(
         queryKeys.plannedMeals.all,
         context?.previousPlannedMealsMetadata
-      )
-      options.onError?.(error, variables, context)
+      );
+      options.onError?.(error, variables, context);
     },
     onSettled: (data, error, variables, context) => {
-      options.onSettled?.(data, error, variables, context)
-      queryClient.invalidateQueries({ queryKey: queryKeys.plannedMeals.all })
+      options.onSettled?.(data, error, variables, context);
+      queryClient.invalidateQueries({ queryKey: queryKeys.plannedMeals.all });
       queryClient.invalidateQueries({
         queryKey: queryKeys.plannedMeals.byId(id),
-      })
-      queryClient.invalidateQueries({ queryKey: queryKeys.recipes.all })
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.recipes.all });
     },
-  })
-}
+  });
+};

--- a/lib/api/hooks/recipes.ts
+++ b/lib/api/hooks/recipes.ts
@@ -56,8 +56,20 @@ export const useDeleteRecipeById = ({
   return useMutation({
     ...options,
     mutationFn: async () => await deleteRecipeById(id),
+    onMutate: async () => {
+      // Cancel any outgoing queries for this recipe to prevent race conditions
+      await queryClient.cancelQueries({
+        queryKey: queryKeys.recipes.byId(id),
+      })
+    },
     onSuccess: (data, variables, context) => {
       options.onSuccess?.(data, variables, context)
+      
+      // Remove the specific recipe from cache instead of just invalidating
+      queryClient.removeQueries({
+        queryKey: queryKeys.recipes.byId(id),
+      })
+      
       queryClient.invalidateQueries({
         queryKey: queryKeys.recipes.all,
       })


### PR DESCRIPTION
## Summary
- Improve recipe suggestion tool clarity and wording for better user experience
- Fix maxSteps functionality to enable sequential tool calls in chat
- Resolve race condition errors during recipe and planned meal deletion

## Changes Made

### Recipe Suggestion Tool Improvements
- Rename `renderRecipePreviewTool` to `renderRecipeSuggestionTool` for better clarity
- Update tool description to emphasize suggestions without creating recipes
- Replace `RecipePreviewCard` with `RecipeSuggestionCard` component

### Chat Sequential Actions Fix
- Switch from `gpt-4.1-mini` to `gpt-4.1` with `parallelToolCalls: false`
- Add error handling to planning assistant route
- This enables proper sequential tool execution when `maxSteps > 1`

### Deletion Race Condition Fixes
- Return proper 404 instead of 500 when resources not found
- Use `router.replace()` instead of `push()` to prevent back navigation to deleted items
- Cancel ongoing queries and remove deleted items from cache to prevent API calls during navigation
- Add better error handling and logging for debugging

## Test Plan
- [x] Recipe suggestions render correctly with new naming
- [x] Chat can perform multiple sequential actions when requested
- [x] Recipe deletion works without console errors
- [x] Planned meal deletion works without console errors
- [x] Navigation prevents returning to deleted items

## Impact
- Better UX with clearer tool naming and descriptions
- Chat now properly executes multiple actions in sequence as intended
- Eliminates console error spam during deletion operations
- Prevents users from navigating back to deleted content