### PR TITLE
Replace Recipe/PlannedMeal with RecipeTemplate/RecipeInstance model

### DIFF
--- a/__tests__/actions/planned-meal-deadlock.test.ts
+++ b/__tests__/actions/planned-meal-deadlock.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, afterAll } from 'vitest'
 import { createPlannedMealAction } from '@/lib/actions/planned-meals'
 import { createRecipeAction } from '@/lib/actions/recipe'
 import prisma from '@/prisma/client'
-import { PlannedMealStatus } from '@/generated/prisma/client'
 
 // Mock Clerk auth
 vi.mock('@clerk/nextjs/server', () => ({
@@ -19,12 +18,12 @@ describe('Planned Meal Creation Deadlock Tests', () => {
     // Cleanup all test data at the end
     if (testUserIds.length > 0) {
       try {
-        await prisma.plannedMeal.deleteMany({
+        await prisma.recipeInstance.deleteMany({
           where: { 
             userId: { in: testUserIds }
           }
         })
-        await prisma.recipe.deleteMany({
+        await prisma.recipeTemplate.deleteMany({
           where: { 
             userId: { in: testUserIds }
           }
@@ -51,7 +50,7 @@ describe('Planned Meal Creation Deadlock Tests', () => {
       getToken: vi.fn(),
       has: vi.fn(),
       debug: vi.fn()
-    } as unknown as Awaited<ReturnType<typeof mockAuth>>)
+    } as unknown as Parameters<typeof mockAuth.mockResolvedValue>[0])
 
     // First, create a recipe to plan meals from
     const recipe = await createRecipeAction({
@@ -66,16 +65,11 @@ describe('Planned Meal Creation Deadlock Tests', () => {
     }
     testRecipeIds.push(recipe.id)
 
-    const plannedMealData = {
-      recipeId: recipe.id,
-      status: PlannedMealStatus.PLANNED
-    }
-
     // Create 10 planned meals in parallel to trigger potential deadlock
     const promises = Array.from({ length: 10 }, (_, i) => 
       createPlannedMealAction({
-        ...plannedMealData,
-        overrideName: `Planned Meal ${i + 1}`
+        templateId: recipe.id,
+        name: `Planned Meal ${i + 1}`
       })
     )
 

--- a/__tests__/actions/recipe-deadlock.test.ts
+++ b/__tests__/actions/recipe-deadlock.test.ts
@@ -16,7 +16,7 @@ describe('Recipe Creation Deadlock Tests', () => {
     // Cleanup all test users at the end
     if (testUserIds.length > 0) {
       try {
-        await prisma.recipe.deleteMany({
+        await prisma.recipeTemplate.deleteMany({
           where: { 
             userId: { in: testUserIds }
           }
@@ -43,7 +43,7 @@ describe('Recipe Creation Deadlock Tests', () => {
       getToken: vi.fn(),
       has: vi.fn(),
       debug: vi.fn()
-    } as unknown as Awaited<ReturnType<typeof mockAuth>>)
+    } as unknown as Parameters<typeof mockAuth.mockResolvedValue>[0])
 
     const recipeData = {
       name: 'Deadlock Test Recipe',

--- a/app/api/planned-meal/[id]/cook/route.ts
+++ b/app/api/planned-meal/[id]/cook/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { updateStatus } from '@/lib/actions/planned-meals'
-import { PlannedMealStatus } from '@/generated/prisma/client'
+import { RecipeInstanceStatus } from '@/generated/prisma/client'
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params
-  const plannedMeal = await updateStatus(id, PlannedMealStatus.COOKED)
+  const plannedMeal = await updateStatus(id, RecipeInstanceStatus.COOKED)
   return NextResponse.json(plannedMeal)
 }

--- a/app/api/planned-meal/[id]/uncook/route.ts
+++ b/app/api/planned-meal/[id]/uncook/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { updateStatus } from '@/lib/actions/planned-meals'
-import { PlannedMealStatus } from '@/generated/prisma/client'
+import { RecipeInstanceStatus } from '@/generated/prisma/client'
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params
-  const plannedMeal = await updateStatus(id, PlannedMealStatus.PLANNED)
+  const plannedMeal = await updateStatus(id, RecipeInstanceStatus.PLANNED)
   return NextResponse.json(plannedMeal)
 }

--- a/app/api/recipe/[id]/plan/route.ts
+++ b/app/api/recipe/[id]/plan/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createPlannedMealAction } from '@/lib/actions/planned-meals'
-import { PlannedMealStatus } from '@/generated/prisma/client'
 
 export async function POST(
   request: NextRequest,
@@ -8,8 +7,7 @@ export async function POST(
 ) {
   const { id } = await params
   const plannedMeal = await createPlannedMealAction({
-    recipeId: id,
-    status: PlannedMealStatus.PLANNED,
+    templateId: id,
   })
   return NextResponse.json(plannedMeal)
 }

--- a/app/api/supabase-keepalive/route.ts
+++ b/app/api/supabase-keepalive/route.ts
@@ -9,7 +9,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    await prisma.recipe.findFirst();
+    await prisma.recipeTemplate.findFirst();
 
     console.log("Supabase keepalive successful.");
 

--- a/components/cooking/cooking-congratulations-dialog.tsx
+++ b/components/cooking/cooking-congratulations-dialog.tsx
@@ -43,10 +43,7 @@ export function CookingCongratulationsDialog({
           </DialogTitle>
           <DialogDescription className="text-center pt-2 flex flex-col gap-2">
             <span className="font-medium text-primary">
-              You&apos;ve successfully cooked{' '}
-              {plannedMealWithRecipe.overrideName ||
-                plannedMealWithRecipe.recipe.name}
-              !
+              You&apos;ve successfully cooked {plannedMealWithRecipe.name}!
             </span>
             <span className="mt-2">What would you like to do next?</span>
           </DialogDescription>

--- a/components/cooking/cooking-view.tsx
+++ b/components/cooking/cooking-view.tsx
@@ -12,10 +12,9 @@ import { PlannedMealWithRecipe } from "@/lib/types";
 import { useUpdatePlannedMealStatusMutation } from "@/lib/api/hooks/planned-meals";
 import { triggerToolEffects } from "@/lib/ai/tools/effects";
 import { useQueryClient } from "@tanstack/react-query";
-import { PlannedMealStatus } from "@/generated/prisma/browser";
+import { RecipeInstanceStatus } from "@/generated/prisma/browser";
 import { CookingCongratulationsDialog } from "@/components/cooking/cooking-congratulations-dialog";
 import { ChatCanva } from "@/components/chat/chat-canva";
-import { plannedMealToRecipe } from "@/lib/utils/plannedMealUtils";
 import { apiRoutes } from "@/lib/api/api-routes";
 import { routes } from "@/lib/routes";
 import { useUserDietaryPreferences } from "@/lib/api/hooks/preferences";
@@ -38,15 +37,12 @@ export function CookingView({ plannedMealWithRecipe }: CookingViewProps) {
         parts: [
           {
             type: "text",
-            text: `I'll guide you through cooking ${
-              plannedMealWithRecipe.overrideName ||
-              plannedMealWithRecipe.recipe.name
-            }. Let me know if you have questions at any step or want to make changes!`,
+            text: `I'll guide you through cooking ${plannedMealWithRecipe.name}. Let me know if you have questions at any step or want to make changes!`,
           },
         ],
       },
     ],
-    [plannedMealWithRecipe.overrideName, plannedMealWithRecipe.recipe.name]
+    [plannedMealWithRecipe.name]
   );
 
   const transport = useMemo(
@@ -86,20 +82,20 @@ export function CookingView({ plannedMealWithRecipe }: CookingViewProps) {
   const handleMarkUncooked = () => {
     updateCookingStatusMutation.mutate({
       id: plannedMealWithRecipe.id,
-      status: PlannedMealStatus.PLANNED,
+      status: RecipeInstanceStatus.PLANNED,
     });
   };
   const handleMarkCooked = () => {
     updateCookingStatusMutation.mutate({
       id: plannedMealWithRecipe.id,
-      status: PlannedMealStatus.COOKED,
+      status: RecipeInstanceStatus.COOKED,
     });
   };
   const handleGoHome = () => {
     router.push(routes.home);
   };
 
-  const effectiveRecipe = plannedMealToRecipe(plannedMealWithRecipe);
+  const effectiveRecipe = plannedMealWithRecipe;
 
   const markAsCookedButton = (
     <Button
@@ -114,7 +110,7 @@ export function CookingView({ plannedMealWithRecipe }: CookingViewProps) {
   );
   return (
     <div className="flex flex-col h-full">
-      {plannedMealWithRecipe.status === PlannedMealStatus.COOKED && (
+      {plannedMealWithRecipe.status === RecipeInstanceStatus.COOKED && (
         <CookingCongratulationsDialog
           open={true}
           onOpenChange={() => {}}

--- a/components/planned-meals/planned-meal-chat-view.tsx
+++ b/components/planned-meals/planned-meal-chat-view.tsx
@@ -12,7 +12,6 @@ import { routes } from "@/lib/routes";
 import { PlannedMealWithRecipe } from "@/lib/types";
 import { apiRoutes } from "@/lib/api/api-routes";
 import { useRouter } from "next/navigation";
-import { plannedMealToRecipe } from "@/lib/utils/plannedMealUtils";
 import { Button } from "@/components/ui/button";
 import { Trash } from "lucide-react";
 import { DeleteConfirmationDialog } from "@/components/ui/delete-confirmation-dialog";
@@ -76,7 +75,7 @@ export function PlannedMealChatView({ plannedMeal }: PlannedMealChatViewProps) {
     [sendMessage, plannedMeal, userDietaryPreferences?.preferences]
   );
 
-  const plannedMealAsRecipe = plannedMealToRecipe(plannedMeal);
+  const plannedMealAsRecipe = plannedMeal;
 
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const deleteAction = (

--- a/components/recipes/recipe-chat-view.tsx
+++ b/components/recipes/recipe-chat-view.tsx
@@ -5,7 +5,7 @@ import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, UIMessage } from "ai";
 import { RecipeViewer } from "@/components/recipes/recipe-viewer";
 import { useRouter } from "next/navigation";
-import { Recipe } from "@/generated/prisma/browser";
+import { RecipeTemplate } from "@/generated/prisma/browser";
 import { triggerToolEffects } from "@/lib/ai/tools/effects";
 import { useQueryClient } from "@tanstack/react-query";
 import { useDeleteRecipeById } from "@/lib/api/hooks/recipes";
@@ -18,7 +18,7 @@ import { routes } from "@/lib/routes";
 import { useUserDietaryPreferences } from "@/lib/api/hooks/preferences";
 
 interface RecipeChatViewProps {
-  recipe: Recipe;
+  recipe: RecipeTemplate;
 }
 
 const initialMessages: UIMessage[] = [

--- a/components/recipes/recipe-viewer.tsx
+++ b/components/recipes/recipe-viewer.tsx
@@ -1,9 +1,15 @@
-import { Recipe } from '@/generated/prisma/browser'
+import { RecipeTemplate } from '@/generated/prisma/browser'
 import { MemoizedMarkdown } from '@/components/chat/memoized-markdown'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import { RecipeMetadataDescription } from './shared/recipe-card-base'
-export function RecipeViewer({ recipe }: { recipe: Recipe }) {
+
+type ViewableRecipe = Pick<
+  RecipeTemplate,
+  'id' | 'name' | 'ingredients' | 'instructions' | 'duration' | 'difficulty' | 'servings'
+>
+
+export function RecipeViewer({ recipe }: { recipe: ViewableRecipe }) {
   return (
     <ScrollArea className="h-full">
       <div className="p-6 space-y-8">

--- a/lib/actions/planned-meals.ts
+++ b/lib/actions/planned-meals.ts
@@ -18,11 +18,7 @@ import {
 } from '@/lib/validators/plannedMeals'
 import { PlannedMealMetadata, PlannedMealWithRecipe } from '@/lib/types'
 import prisma from '@/prisma/client'
-import { PlannedMealStatus } from '@/generated/prisma/client'
-import {
-  decrementCookedCount,
-  incrementCookedCount,
-} from '@/lib/data-access/recipe'
+import { RecipeInstanceStatus } from '@/generated/prisma/client'
 import { MAX_NUM_PLANNED_MEALS_PER_USER } from '@/lib/constants/app_validation'
 
 export const getPlannedMealsMetadataAction = async (): Promise<
@@ -58,8 +54,8 @@ export const createPlannedMealAction = async (
     const plannedMeal = await prisma.$transaction(
       async (tx) => {
         // Check count first to give user immediate feedback for obvious violations
-        const count = await tx.plannedMeal.count({
-          where: { userId, status: PlannedMealStatus.PLANNED },
+        const count = await tx.recipeInstance.count({
+          where: { userId, status: RecipeInstanceStatus.PLANNED },
         })
 
         if (count >= MAX_NUM_PLANNED_MEALS_PER_USER) {
@@ -122,7 +118,7 @@ export const getPlannedMealByIdAction = async (
 
 export async function updateStatus(
   plannedMealId: string,
-  status: PlannedMealStatus
+  status: RecipeInstanceStatus
 ) {
   const { userId } = await auth()
   if (!userId) {
@@ -142,30 +138,18 @@ export async function updateStatus(
 
     if (plannedMeal.status === status) return plannedMeal
 
-    if (status === PlannedMealStatus.COOKED) {
-      const plannedMeal = await setPlannedMealCooked({
+    if (status === RecipeInstanceStatus.COOKED) {
+      return setPlannedMealCooked({
         id: plannedMealId,
-        userId,
-        transaction: tx,
-      })
-      await incrementCookedCount({
-        id: plannedMeal.recipeId,
-        userId,
-        transaction: tx,
-      })
-    } else {
-      const plannedMeal = await setPlannedMealUnCooked({
-        id: plannedMealId,
-        userId,
-        transaction: tx,
-      })
-      await decrementCookedCount({
-        id: plannedMeal.recipeId,
         userId,
         transaction: tx,
       })
     }
 
-    return plannedMeal
+    return setPlannedMealUnCooked({
+      id: plannedMealId,
+      userId,
+      transaction: tx,
+    })
   })
 }

--- a/lib/actions/recipe.ts
+++ b/lib/actions/recipe.ts
@@ -30,8 +30,8 @@ export const createRecipeAction = async (recipeData: CreateRecipeInput) => {
     const recipe = await prisma.$transaction(
       async (tx) => {
         // Check count first to give user immediate feedback for obvious violations
-        const count = await tx.recipe.count({
-          where: { userId },
+        const count = await tx.recipeTemplate.count({
+          where: { userId, archivedAt: null },
         })
 
         if (count >= MAX_NUM_RECIPES_PER_USER) {
@@ -40,7 +40,7 @@ export const createRecipeAction = async (recipeData: CreateRecipeInput) => {
           )
         }
 
-        return tx.recipe.create({
+        return tx.recipeTemplate.create({
           data: {
             ...recipeData,
             userId,

--- a/lib/ai/tools/definitions.ts
+++ b/lib/ai/tools/definitions.ts
@@ -13,7 +13,7 @@ import {
   PlannedMealMetadata,
   asTypedSchema,
 } from "@/lib/types";
-import { Recipe, PlannedMeal } from "@/generated/prisma/browser";
+import { RecipeTemplate, RecipeInstance } from "@/generated/prisma/browser";
 
 export const getRecipesMetadataDefinition = defineTool({
   description: "Get the metadata of all recipes belonging to the user.",
@@ -32,7 +32,7 @@ export const getPlannedMealsDefinition = defineTool({
   description:
     "Get all planned meals with status PLANNED belonging to the user. Useful for fetching all ingredients of upcoming meals.",
   inputSchema: z.object({}),
-  result: asTypedSchema<PlannedMeal[]>(),
+  result: asTypedSchema<RecipeInstance[]>(),
 });
 
 export const getRecipeByIdDefinition = defineTool({
@@ -40,7 +40,7 @@ export const getRecipeByIdDefinition = defineTool({
   inputSchema: z.object({
     id: z.string().describe("The ID of the recipe to get"),
   }),
-  result: asTypedSchema<Recipe>(),
+  result: asTypedSchema<RecipeTemplate>(),
 });
 
 export const getPlannedMealByIdDefinition = defineTool({
@@ -48,31 +48,31 @@ export const getPlannedMealByIdDefinition = defineTool({
   inputSchema: z.object({
     id: z.string().describe("The ID of the planned meal to get"),
   }),
-  result: asTypedSchema<PlannedMeal>(),
+  result: asTypedSchema<RecipeInstance>(),
 });
 
 export const createRecipeDefinition = defineTool({
   description: "Create a Recipe object.",
   inputSchema: createRecipeInputSchema,
-  result: asTypedSchema<Recipe>(),
+  result: asTypedSchema<RecipeTemplate>(),
 });
 
 export const createPlannedMealDefinition = defineTool({
   description: "Create a PlannedMeal object.",
   inputSchema: createPlannedMealInputSchema,
-  result: asTypedSchema<PlannedMeal>(),
+  result: asTypedSchema<RecipeInstance>(),
 });
 
 export const updateRecipeDefinition = defineTool({
   description: "Update a Recipe object.",
   inputSchema: updateRecipeInputSchema,
-  result: asTypedSchema<Recipe>(),
+  result: asTypedSchema<RecipeTemplate>(),
 });
 
 export const updatePlannedMealDefinition = defineTool({
   description: "Update a PlannedMeal object.",
   inputSchema: updatePlannedMealInputSchema,
-  result: asTypedSchema<PlannedMeal>(),
+  result: asTypedSchema<RecipeInstance>(),
 });
 
 export const deleteRecipeDefinition = defineTool({

--- a/lib/ai/tools/renderer.tsx
+++ b/lib/ai/tools/renderer.tsx
@@ -6,7 +6,7 @@ import {
   ToolError,
 } from "@/components/chat/tool-feedback";
 import { PlannedMealMetadata, RecipeMetadata } from "@/lib/types";
-import { PlannedMeal, Recipe } from "@/generated/prisma/browser";
+import { RecipeInstance, RecipeTemplate } from "@/generated/prisma/browser";
 import { ToolResult } from "@/lib/ai/tools/types";
 import { CreateRecipeInput } from "@/lib/validators/recipe";
 
@@ -101,42 +101,42 @@ const renderGetPlannedMealsTool = toolMessageRenderer<PlannedMealMetadata[]>({
     `Retrieved ${data.length} planned meal${data.length > 1 ? "s" : ""}!`,
 });
 
-const renderCreateRecipeTool = toolMessageRenderer<Recipe>({
+const renderCreateRecipeTool = toolMessageRenderer<RecipeTemplate>({
   loadingMessage: "Creating recipe...",
   successMessage: (data) => `Recipe "${data.name}" created successfully!`,
 });
 
-const renderCreatePlannedMealTool = toolMessageRenderer<PlannedMeal>({
+const renderCreatePlannedMealTool = toolMessageRenderer<RecipeInstance>({
   loadingMessage: "Planning recipe...",
   successMessage: () => "Recipe planned successfully!",
 });
 
-const renderDeleteRecipeTool = toolMessageRenderer<Recipe>({
+const renderDeleteRecipeTool = toolMessageRenderer<RecipeTemplate>({
   loadingMessage: "Deleting recipe...",
   successMessage: () => "Recipe deleted successfully!",
 });
 
-const renderDeletePlannedMealTool = toolMessageRenderer<PlannedMeal>({
+const renderDeletePlannedMealTool = toolMessageRenderer<RecipeInstance>({
   loadingMessage: "Deleting planned meal...",
   successMessage: () => "Planned meal deleted successfully!",
 });
 
-const renderUpdateRecipeTool = toolMessageRenderer<Recipe>({
+const renderUpdateRecipeTool = toolMessageRenderer<RecipeTemplate>({
   loadingMessage: "Updating recipe...",
   successMessage: () => "Recipe updated successfully!",
 });
 
-const renderUpdatePlannedMealTool = toolMessageRenderer<PlannedMeal>({
+const renderUpdatePlannedMealTool = toolMessageRenderer<RecipeInstance>({
   loadingMessage: "Updating planned meal...",
   successMessage: () => "Planned meal updated successfully!",
 });
 
-const renderGetRecipeByIdTool = toolMessageRenderer<Recipe>({
+const renderGetRecipeByIdTool = toolMessageRenderer<RecipeTemplate>({
   loadingMessage: "Retrieving recipe...",
   successMessage: () => "Recipe retrieved successfully!",
 });
 
-const renderGetPlannedMealByIdTool = toolMessageRenderer<PlannedMeal>({
+const renderGetPlannedMealByIdTool = toolMessageRenderer<RecipeInstance>({
   loadingMessage: "Retrieving planned meal...",
   successMessage: () => "Planned meal retrieved successfully!",
 });

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -6,9 +6,9 @@ import {
   RecipeMetadata,
 } from "@/lib/types";
 import {
-  PlannedMeal,
-  PlannedMealStatus,
-  Recipe,
+  RecipeInstance,
+  RecipeInstanceStatus,
+  RecipeTemplate,
   UserDietaryPreferences,
 } from "@/generated/prisma/browser";
 import { UpdatePlannedMealInput } from "@/lib/validators/plannedMeals";
@@ -21,7 +21,7 @@ export async function getPlannedMealWithRecipeById(
 export const updatePlannedMeal = async (
   updatePlannedMealInput: UpdatePlannedMealInput
 ) => {
-  return put<PlannedMeal>(
+  return put<RecipeInstance>(
     apiRoutes.plannedMeal.byId(updatePlannedMealInput.id),
     updatePlannedMealInput
   );
@@ -36,7 +36,7 @@ export const getRecipesMetadata = async () => {
 };
 
 export const getRecipeById = async (id: string) => {
-  return get<Recipe>(apiRoutes.recipe.byId(id));
+  return get<RecipeTemplate>(apiRoutes.recipe.byId(id));
 };
 
 export const deleteRecipeById = async (
@@ -47,17 +47,17 @@ export const deleteRecipeById = async (
 
 export const updatePlannedMealStatus = async (
   id: string,
-  status: PlannedMealStatus
+  status: RecipeInstanceStatus
 ) => {
   const url =
-    status === PlannedMealStatus.COOKED
+    status === RecipeInstanceStatus.COOKED
       ? apiRoutes.plannedMeal.cook(id)
       : apiRoutes.plannedMeal.uncook(id);
-  return post<PlannedMeal>(url, {});
+  return post<RecipeInstance>(url, {});
 };
 
 export const planRecipe = async (id: string) => {
-  return post<PlannedMeal>(apiRoutes.recipe.plan(id), {});
+  return post<RecipeInstance>(apiRoutes.recipe.plan(id), {});
 };
 
 export const deletePlannedMealById = async (id: string) => {

--- a/lib/api/hooks/planned-meals.ts
+++ b/lib/api/hooks/planned-meals.ts
@@ -6,7 +6,7 @@ import {
   UseQueryOptions,
 } from "@tanstack/react-query";
 import { PlannedMealWithRecipe, PlannedMealMetadata } from "@/lib/types";
-import { PlannedMeal, PlannedMealStatus } from "@/generated/prisma/browser";
+import { RecipeInstance, RecipeInstanceStatus } from "@/generated/prisma/browser";
 import {
   getPlannedMealsMetadata,
   getPlannedMealWithRecipeById,
@@ -51,7 +51,7 @@ export const usePlannedMealsMetadata = ({
 
 type CookedStatusVars = {
   id: string;
-  status: PlannedMealStatus;
+  status: RecipeInstanceStatus;
 };
 
 type StatusMutationContext = {
@@ -64,7 +64,7 @@ export const useUpdatePlannedMealStatusMutation = ({
 }: {
   options?: Omit<
     UseMutationOptions<
-      PlannedMeal,
+      RecipeInstance,
       Error,
       CookedStatusVars,
       StatusMutationContext
@@ -139,9 +139,9 @@ export const useUpdatePlannedMealStatusMutation = ({
       queryClient.invalidateQueries({
         queryKey: queryKeys.plannedMeals.byId(variables.id),
       });
-      if (data?.recipeId) {
+      if (data?.templateId) {
         queryClient.invalidateQueries({
-          queryKey: queryKeys.recipes.byId(data.recipeId),
+          queryKey: queryKeys.recipes.byId(data.templateId),
         });
       }
     },
@@ -152,7 +152,7 @@ export const useUpdatePlannedMealMutation = ({
   options = {},
 }: {
   options?: Omit<
-    UseMutationOptions<PlannedMeal, Error, UpdatePlannedMealInput>,
+    UseMutationOptions<RecipeInstance, Error, UpdatePlannedMealInput>,
     "mutationFn"
   >;
 } = {}) => {

--- a/lib/api/hooks/recipes.ts
+++ b/lib/api/hooks/recipes.ts
@@ -15,7 +15,7 @@ import {
   planRecipe,
 } from '@/lib/api/client'
 import { queryKeys } from '../query-keys'
-import { PlannedMeal, Recipe } from '@/generated/prisma/browser'
+import { RecipeInstance, RecipeTemplate } from '@/generated/prisma/browser'
 export const useRecipesMetadata = ({
   options = {},
 }: {
@@ -36,7 +36,7 @@ export const useRecipeById = ({
   options = {},
 }: {
   id: string
-  options?: Omit<UseQueryOptions<Recipe, Error>, 'queryKey' | 'queryFn'>
+  options?: Omit<UseQueryOptions<RecipeTemplate, Error>, 'queryKey' | 'queryFn'>
 }) => {
   return useQuery({
     ...options,
@@ -83,7 +83,7 @@ export const useDeleteRecipeById = ({
 export const usePlanRecipe = ({
   options = {},
 }: {
-  options?: Omit<UseMutationOptions<PlannedMeal, Error, string>, 'mutationFn'>
+  options?: Omit<UseMutationOptions<RecipeInstance, Error, string>, 'mutationFn'>
 } = {}) => {
   const queryClient = useQueryClient()
   return useMutation({

--- a/lib/constants/models_validation.ts
+++ b/lib/constants/models_validation.ts
@@ -20,6 +20,3 @@ export const MIN_DIFFICULTY = 1
 
 export const MAX_DURATION_MINUTES = 600
 export const MIN_DURATION_MINUTES = 1
-
-export const MAX_COOK_COUNT = 1000
-export const MIN_COOK_COUNT = 0

--- a/lib/data-access/planned-meal.ts
+++ b/lib/data-access/planned-meal.ts
@@ -4,7 +4,7 @@ import {
   CreatePlannedMealInput,
   UpdatePlannedMealInput,
 } from '@/lib/validators/plannedMeals'
-import { PlannedMealStatus } from '@/generated/prisma/client'
+import { RecipeInstanceStatus } from '@/generated/prisma/client'
 import { handleDbError } from '@/lib/utils/error'
 import { PlannedMealMetadata, PlannedMealWithRecipe } from '@/lib/types'
 
@@ -17,11 +17,29 @@ export async function createPlannedMeal({
   userId: string
   data: CreatePlannedMealInput
 }) {
+  const { templateId, ...overrides } = data
+  const client = transaction ?? prisma
   try {
-    const plannedMeal = await (transaction ?? prisma).plannedMeal.create({
+    const template = await client.recipeTemplate.findUnique({
+      where: { id: templateId, userId },
+    })
+
+    if (!template) {
+      throw new Error(`Recipe template with ID ${templateId} not found`)
+    }
+
+    const plannedMeal = await client.recipeInstance.create({
       data: {
-        ...data,
         userId,
+        templateId,
+        name: overrides.name ?? template.name,
+        servings: overrides.servings ?? template.servings,
+        ingredients: overrides.ingredients ?? template.ingredients,
+        instructions: overrides.instructions ?? template.instructions,
+        duration: overrides.duration ?? template.duration,
+        difficulty: overrides.difficulty ?? template.difficulty,
+        status: overrides.status ?? RecipeInstanceStatus.PLANNED,
+        cookedAt: overrides.cookedAt,
       },
     })
     return plannedMeal
@@ -40,13 +58,10 @@ export async function getPlannedMealById({
   userId: string
 }): Promise<PlannedMealWithRecipe> {
   try {
-    const plannedMeal = await (transaction ?? prisma).plannedMeal.findUnique({
+    const plannedMeal = await (transaction ?? prisma).recipeInstance.findUnique({
       where: {
         id,
         userId,
-      },
-      include: {
-        recipe: true,
       },
     })
 
@@ -69,25 +84,17 @@ export async function getPlannedMealsMetadata({
 }): Promise<PlannedMealMetadata[]> {
   try {
     // TODO: Add pagination
-    const plannedMeals = await (transaction ?? prisma).plannedMeal.findMany({
-      where: { userId, status: PlannedMealStatus.PLANNED },
+    const plannedMeals = await (transaction ?? prisma).recipeInstance.findMany({
+      where: { userId, status: RecipeInstanceStatus.PLANNED },
       select: {
         id: true,
-        overrideName: true,
+        name: true,
         createdAt: true,
-        overrideDifficulty: true,
-        overrideDuration: true,
-        overrideServings: true,
+        difficulty: true,
+        duration: true,
+        servings: true,
         status: true,
         cookedAt: true,
-        recipe: {
-          select: {
-            name: true,
-            servings: true,
-            duration: true,
-            difficulty: true,
-          },
-        },
       },
       orderBy: { createdAt: 'desc' },
     })
@@ -105,8 +112,8 @@ export async function getPlannedMeals({
   userId: string
 }) {
   try {
-    const plannedMeals = await (transaction ?? prisma).plannedMeal.findMany({
-      where: { userId, status: PlannedMealStatus.PLANNED },
+    const plannedMeals = await (transaction ?? prisma).recipeInstance.findMany({
+      where: { userId, status: RecipeInstanceStatus.PLANNED },
     })
     return plannedMeals
   } catch (error) {
@@ -125,7 +132,7 @@ export async function updatePlannedMeal({
 }) {
   try {
     const { id, ...updateData } = data
-    const plannedMeal = await (transaction ?? prisma).plannedMeal.update({
+    const plannedMeal = await (transaction ?? prisma).recipeInstance.update({
       where: { id, userId },
       data: updateData,
     })
@@ -148,7 +155,7 @@ export async function setPlannedMealCooked({
     const plannedMeal = await updatePlannedMeal({
       transaction,
       userId,
-      data: { id, cookedAt: new Date(), status: PlannedMealStatus.COOKED },
+      data: { id, cookedAt: new Date(), status: RecipeInstanceStatus.COOKED },
     })
     return plannedMeal
   } catch (error) {
@@ -169,7 +176,7 @@ export async function setPlannedMealUnCooked({
     const plannedMeal = await updatePlannedMeal({
       transaction,
       userId,
-      data: { id, cookedAt: undefined, status: PlannedMealStatus.PLANNED },
+      data: { id, cookedAt: undefined, status: RecipeInstanceStatus.PLANNED },
     })
     return plannedMeal
   } catch (error) {
@@ -187,7 +194,7 @@ export async function deletePlannedMeal({
   userId: string
 }) {
   try {
-    await (transaction ?? prisma).plannedMeal.delete({
+    await (transaction ?? prisma).recipeInstance.delete({
       where: { id, userId },
     })
     return true

--- a/lib/data-access/recipe.ts
+++ b/lib/data-access/recipe.ts
@@ -1,5 +1,5 @@
 import prisma from "@/prisma/client";
-import { PlannedMealStatus, Prisma } from "@/generated/prisma/client";
+import { RecipeInstanceStatus, Prisma } from "@/generated/prisma/client";
 import { CreateRecipeInput, UpdateRecipeInput } from "@/lib/validators/recipe";
 import { handleDbError } from "@/lib/utils/error";
 import { RecipeMetadata } from "@/lib/types";
@@ -14,7 +14,7 @@ export async function createRecipe({
   data: CreateRecipeInput;
 }) {
   try {
-    const recipe = await (transaction ?? prisma).recipe.create({
+    const recipe = await (transaction ?? prisma).recipeTemplate.create({
       data: {
         ...data,
         userId,
@@ -36,7 +36,7 @@ export async function getRecipeById({
   userId: string;
 }) {
   try {
-    const recipe = await (transaction ?? prisma).recipe.findUnique({
+    const recipe = await (transaction ?? prisma).recipeTemplate.findUnique({
       where: { id, userId },
     });
 
@@ -59,9 +59,10 @@ export async function getRecipesMetadata({
 }): Promise<RecipeMetadata[]> {
   // TODO: Add pagination
   try {
-    const recipes = await (transaction ?? prisma).recipe.findMany({
+    const templates = await (transaction ?? prisma).recipeTemplate.findMany({
       where: {
         userId,
+        archivedAt: null,
       },
       select: {
         id: true,
@@ -70,23 +71,33 @@ export async function getRecipesMetadata({
         servings: true,
         duration: true,
         difficulty: true,
-        cookCount: true,
         isFavorite: true,
-        plannedMeals: {
+        instances: {
           where: {
-            status: PlannedMealStatus.PLANNED,
+            status: {
+              in: [RecipeInstanceStatus.PLANNED, RecipeInstanceStatus.COOKED],
+            },
           },
           select: {
             id: true,
-            status: true,            
-          }
-        }
+            status: true,
+          },
+        },
       },
       orderBy: {
         createdAt: "desc",
       },
     });
-    return recipes;
+
+    return templates.map(({ instances, ...template }) => ({
+      ...template,
+      plannedMeals: instances.filter(
+        (instance) => instance.status === RecipeInstanceStatus.PLANNED
+      ),
+      cookCount: instances.filter(
+        (instance) => instance.status === RecipeInstanceStatus.COOKED
+      ).length,
+    }));
   } catch (error) {
     handleDbError(error, "list recipes");
   }
@@ -102,7 +113,7 @@ export async function updateRecipe({
 }) {
   const { id, ...recipeData } = data;
   try {
-    const recipe = await (transaction ?? prisma).recipe.update({
+    const recipe = await (transaction ?? prisma).recipeTemplate.update({
       where: { id, userId },
       data: recipeData,
     });
@@ -145,8 +156,11 @@ export async function deleteRecipe({
   userId: string;
 }) {
   try {
-    await (transaction ?? prisma).recipe.delete({
+    // Soft delete: planned/cooked instances keep a valid template reference and
+    // their cooking history, so we archive the template instead of removing it.
+    await (transaction ?? prisma).recipeTemplate.update({
       where: { id, userId },
+      data: { archivedAt: new Date() },
     });
     return true;
   } catch (error) {
@@ -157,46 +171,5 @@ export async function deleteRecipe({
       }
     }
     handleDbError(error, "delete recipe");
-  }
-}
-
-
-export async function incrementCookedCount({
-  id,
-  userId,
-  transaction,
-}: {
-  id: string;
-  userId: string;
-  transaction?: Prisma.TransactionClient;
-}) {
-  try {
-    const recipe = await (transaction ?? prisma).recipe.update({
-      where: { id, userId },
-      data: { cookCount: { increment: 1 } },
-    });
-    return recipe;
-  } catch (error) {
-    handleDbError(error, "increment cooked count");
-  }
-}
-
-export async function decrementCookedCount({
-  id,
-  userId,
-  transaction,
-}: {
-  id: string;
-  userId: string;
-  transaction?: Prisma.TransactionClient;
-}) {
-  try {
-    const recipe = await (transaction ?? prisma).recipe.update({
-      where: { id, userId },
-      data: { cookCount: { decrement: 1} },
-    });
-    return recipe;
-  } catch (error) {
-    handleDbError(error, "decrement cooked count");
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,60 +1,42 @@
-import { Prisma, Recipe } from '@/generated/prisma/browser'
+import {
+  RecipeTemplate,
+  RecipeInstance,
+  RecipeInstanceStatus,
+} from '@/generated/prisma/browser'
 import { z } from 'zod'
 
 export type CardDisplayMetadata = Pick<
-  Recipe,
+  RecipeTemplate,
   'id' | 'name' | 'duration' | 'difficulty' | 'servings'
 >
 
-export type RecipeMetadata = Prisma.RecipeGetPayload<{
-  select: {
-    id: true
-    name: true
-    createdAt: true
-    servings: true
-    duration: true
-    difficulty: true
-    cookCount: true
-    isFavorite: true
-    plannedMeals: {
-      where: {
-        // TODO: This is a workaround to get the type to work. Should use the enum instead.
-        status: 'PLANNED'
-      }
-      select: {
-        id: true
-        status: true
-      }
-    }
-  }
-}>
+export type RecipeMetadata = Pick<
+  RecipeTemplate,
+  | 'id'
+  | 'name'
+  | 'createdAt'
+  | 'servings'
+  | 'duration'
+  | 'difficulty'
+  | 'isFavorite'
+> & {
+  cookCount: number
+  plannedMeals: { id: string; status: RecipeInstanceStatus }[]
+}
 
-export type PlannedMealMetadata = Prisma.PlannedMealGetPayload<{
-  select: {
-    id: true
-    overrideName: true
-    createdAt: true
-    overrideDifficulty: true
-    overrideDuration: true
-    overrideServings: true
-    status: true
-    cookedAt: true
-    recipe: {
-      select: {
-        name: true
-        servings: true
-        duration: true
-        difficulty: true
-      }
-    }
-  }
-}>
+export type PlannedMealMetadata = Pick<
+  RecipeInstance,
+  | 'id'
+  | 'name'
+  | 'createdAt'
+  | 'difficulty'
+  | 'duration'
+  | 'servings'
+  | 'status'
+  | 'cookedAt'
+>
 
-export type PlannedMealWithRecipe = Prisma.PlannedMealGetPayload<{
-  include: {
-    recipe: true
-  }
-}>
+export type PlannedMealWithRecipe = RecipeInstance
 
 // bypasses a zod schema and accept a type instead. Can be used to type safe values
 export const asTypedSchema = <T>() => ({} as unknown as z.ZodType<T>)

--- a/lib/utils/plannedMealUtils.ts
+++ b/lib/utils/plannedMealUtils.ts
@@ -1,36 +1,4 @@
-import {
-  CardDisplayMetadata,
-  PlannedMealMetadata,
-  PlannedMealWithRecipe,
-} from '@/lib/types'
-
-/**
- * Converts a planned meal with recipe to a recipe object, using override values when available
- */
-export const plannedMealToRecipe = (
-  plannedMealWithRecipe: PlannedMealWithRecipe
-) => {
-  return {
-    ...plannedMealWithRecipe.recipe,
-    name:
-      plannedMealWithRecipe.overrideName || plannedMealWithRecipe.recipe.name,
-    ingredients: plannedMealWithRecipe.overrideIngredients?.length
-      ? plannedMealWithRecipe.overrideIngredients
-      : plannedMealWithRecipe.recipe.ingredients,
-    instructions:
-      plannedMealWithRecipe.overrideInstructions ||
-      plannedMealWithRecipe.recipe.instructions,
-    servings:
-      plannedMealWithRecipe.overrideServings ||
-      plannedMealWithRecipe.recipe.servings,
-    duration:
-      plannedMealWithRecipe.overrideDuration ||
-      plannedMealWithRecipe.recipe.duration,
-    difficulty:
-      plannedMealWithRecipe.overrideDifficulty ||
-      plannedMealWithRecipe.recipe.difficulty,
-  }
-}
+import { CardDisplayMetadata, PlannedMealMetadata } from '@/lib/types'
 
 /**
  * Extracts card display metadata from a planned meal
@@ -40,9 +8,9 @@ export const getPlannedMealDisplayMetadata = (
 ): CardDisplayMetadata => {
   return {
     id: plannedMeal.id,
-    name: plannedMeal.overrideName || plannedMeal.recipe.name,
-    duration: plannedMeal.overrideDuration || plannedMeal.recipe.duration,
-    difficulty: plannedMeal.overrideDifficulty || plannedMeal.recipe.difficulty,
-    servings: plannedMeal.overrideServings || plannedMeal.recipe.servings,
+    name: plannedMeal.name,
+    duration: plannedMeal.duration,
+    difficulty: plannedMeal.difficulty,
+    servings: plannedMeal.servings,
   }
 }

--- a/lib/validators/plannedMeals.ts
+++ b/lib/validators/plannedMeals.ts
@@ -15,18 +15,18 @@ import {
   MIN_INGREDIENT_LENGTH,
   MAX_INGREDIENT_LENGTH,
 } from '@/lib/constants/models_validation'
-import { PlannedMealStatus } from '@/generated/prisma/browser'
+import { RecipeInstanceStatus } from '@/generated/prisma/browser'
 
 export const createPlannedMealInputSchema = z
   .object({
-    recipeId: z
+    templateId: z
       .string()
-      .nonempty({ message: 'Recipe ID is required' })
+      .nonempty({ message: 'Recipe template ID is required' })
       .describe('The ID of the recipe to plan. Required.'),
-    overrideName: z
+    name: z
       .string()
       .describe(
-        "The name of the planned meal. Leave empty if no change compared to the original recipe, otherwise adjust it to reflect the changes, e.g. 'Chicken Parmesan' -> 'Chicken Parmesan (with extra cheese)"
+        "The name of the planned meal. Defaults to the recipe's name; set it to reflect changes, e.g. 'Chicken Parmesan' -> 'Chicken Parmesan (with extra cheese)'."
       )
       .min(MIN_NAME_LENGTH, {
         message: `Name must be at least ${MIN_NAME_LENGTH} characters`,
@@ -35,7 +35,7 @@ export const createPlannedMealInputSchema = z
         message: `Name must be less than ${MAX_NAME_LENGTH} characters`,
       })
       .optional(),
-    overrideIngredients: z
+    ingredients: z
       .array(
         z
           .string()
@@ -47,7 +47,7 @@ export const createPlannedMealInputSchema = z
           })
       )
       .describe(
-        'The ingredients of the planned meal. Leave empty if no change compared to the original recipe, otherwise adjust it to reflect the changes.'
+        "The ingredients of the planned meal. Defaults to the recipe's ingredients; set it to reflect changes."
       )
       .min(MIN_INGREDIENTS, {
         message: `Ingredients must be at least ${MIN_INGREDIENTS}`,
@@ -56,10 +56,10 @@ export const createPlannedMealInputSchema = z
         message: `Ingredients must be less than ${MAX_INGREDIENTS}`,
       })
       .optional(),
-    overrideInstructions: z
+    instructions: z
       .string()
       .describe(
-        'The instructions of the planned meal. Leave empty if no change compared to the original recipe, otherwise adjust it to reflect the changes.'
+        "The instructions of the planned meal. Defaults to the recipe's instructions; set it to reflect changes."
       )
       .min(MIN_INSTRUCTIONS_LENGTH, {
         message: `Instructions must be at least ${MIN_INSTRUCTIONS_LENGTH} characters`,
@@ -68,10 +68,10 @@ export const createPlannedMealInputSchema = z
         message: `Instructions must be less than ${MAX_INSTRUCTIONS_LENGTH} characters`,
       })
       .optional(),
-    overrideServings: z
+    servings: z
       .number()
       .describe(
-        'The number of servings of the planned meal. Leave empty if no change compared to the original recipe, otherwise adjust it to reflect the changes.'
+        "The number of servings of the planned meal. Defaults to the recipe's servings; set it to reflect changes."
       )
       .min(MIN_SERVINGS, {
         message: `Servings must be at least ${MIN_SERVINGS}`,
@@ -80,10 +80,10 @@ export const createPlannedMealInputSchema = z
         message: `Servings must be less than ${MAX_SERVINGS}`,
       })
       .optional(),
-    overrideDuration: z
+    duration: z
       .number()
       .describe(
-        'The duration of the planned meal in minutes. Leave empty if no change compared to the original recipe, otherwise adjust it to reflect the changes.'
+        "The duration of the planned meal in minutes. Defaults to the recipe's duration; set it to reflect changes."
       )
       .min(MIN_DURATION_MINUTES, {
         message: `Duration must be at least ${MIN_DURATION_MINUTES} minutes`,
@@ -92,10 +92,10 @@ export const createPlannedMealInputSchema = z
         message: `Duration must be less than ${MAX_DURATION_MINUTES} minutes`,
       })
       .optional(),
-    overrideDifficulty: z
+    difficulty: z
       .number()
       .describe(
-        'The difficulty of the planned meal. Leave empty if no change compared to the original recipe, otherwise adjust it to reflect the changes.'
+        "The difficulty of the planned meal. Defaults to the recipe's difficulty; set it to reflect changes."
       )
       .min(MIN_DIFFICULTY, {
         message: `Difficulty must be at least ${MIN_DIFFICULTY}`,
@@ -105,10 +105,11 @@ export const createPlannedMealInputSchema = z
       })
       .optional(),
     status: z
-      .nativeEnum(PlannedMealStatus)
+      .nativeEnum(RecipeInstanceStatus)
       .describe(
-        'The status of the planned meal. PLANNED if the meal is not cooked yet, COOKED if the meal has been cooked.'
-      ),
+        'The status of the planned meal. Defaults to PLANNED if not provided.'
+      )
+      .optional(),
     cookedAt: z
       .date()
       .describe(
@@ -119,7 +120,7 @@ export const createPlannedMealInputSchema = z
   .strict()
 
 export const updatePlannedMealInputSchema = createPlannedMealInputSchema
-  .omit({ recipeId: true })
+  .omit({ templateId: true })
   .partial()
   .extend({
     id: z.string().describe('The ID of the planned meal to update'),

--- a/lib/validators/recipe.ts
+++ b/lib/validators/recipe.ts
@@ -14,7 +14,6 @@ import {
   MAX_INGREDIENT_LENGTH,
   MIN_INSTRUCTIONS_LENGTH,
   MAX_INSTRUCTIONS_LENGTH,
-  MIN_COOK_COUNT,
   MAX_INGREDIENTS,
 } from '@/lib/constants/models_validation'
 
@@ -96,11 +95,6 @@ export const createRecipeInputSchema = z
     isFavorite: z
       .boolean()
       .describe('Whether the recipe is a favorite')
-      .optional(),
-    cookCount: z
-      .number()
-      .describe('The number of times the recipe has been cooked')
-      .min(0, { message: `Cook count must be at least ${MIN_COOK_COUNT}` })
       .optional(),
   })
   .strict()

--- a/prisma/migrations/20260529075741_recipe_template_and_instance/migration.sql
+++ b/prisma/migrations/20260529075741_recipe_template_and_instance/migration.sql
@@ -1,0 +1,82 @@
+/*
+  Warnings:
+
+  - You are about to drop the `PlannedMeal` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Recipe` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "RecipeInstanceStatus" AS ENUM ('PLANNED', 'COOKING', 'COOKED', 'CANCELLED');
+
+-- DropForeignKey
+ALTER TABLE "PlannedMeal" DROP CONSTRAINT "PlannedMeal_recipeId_fkey";
+
+-- DropTable
+DROP TABLE "PlannedMeal";
+
+-- DropTable
+DROP TABLE "Recipe";
+
+-- DropEnum
+DROP TYPE "PlannedMealStatus";
+
+-- CreateTable
+CREATE TABLE "RecipeTemplate" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "servings" INTEGER NOT NULL,
+    "ingredients" TEXT[],
+    "instructions" VARCHAR(10000) NOT NULL,
+    "duration" INTEGER,
+    "difficulty" INTEGER,
+    "isFavorite" BOOLEAN NOT NULL DEFAULT false,
+    "archivedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RecipeTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RecipeInstance" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "templateId" TEXT NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "servings" INTEGER NOT NULL,
+    "ingredients" TEXT[],
+    "instructions" VARCHAR(10000) NOT NULL,
+    "duration" INTEGER,
+    "difficulty" INTEGER,
+    "status" "RecipeInstanceStatus" NOT NULL DEFAULT 'PLANNED',
+    "plannedFor" TIMESTAMP(3),
+    "startedAt" TIMESTAMP(3),
+    "cookedAt" TIMESTAMP(3),
+    "cancelledAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RecipeInstance_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "RecipeTemplate_userId_idx" ON "RecipeTemplate"("userId");
+
+-- CreateIndex
+CREATE INDEX "RecipeTemplate_userId_archivedAt_idx" ON "RecipeTemplate"("userId", "archivedAt");
+
+-- CreateIndex
+CREATE INDEX "RecipeInstance_userId_status_idx" ON "RecipeInstance"("userId", "status");
+
+-- CreateIndex
+CREATE INDEX "RecipeInstance_userId_plannedFor_idx" ON "RecipeInstance"("userId", "plannedFor");
+
+-- CreateIndex
+CREATE INDEX "RecipeInstance_userId_cookedAt_idx" ON "RecipeInstance"("userId", "cookedAt");
+
+-- CreateIndex
+CREATE INDEX "RecipeInstance_templateId_idx" ON "RecipeInstance"("templateId");
+
+-- AddForeignKey
+ALTER TABLE "RecipeInstance" ADD CONSTRAINT "RecipeInstance_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "RecipeTemplate"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260529082314_tighten_indexes/migration.sql
+++ b/prisma/migrations/20260529082314_tighten_indexes/migration.sql
@@ -1,0 +1,26 @@
+-- DropIndex
+DROP INDEX "RecipeInstance_templateId_idx";
+
+-- DropIndex
+DROP INDEX "RecipeInstance_userId_cookedAt_idx";
+
+-- DropIndex
+DROP INDEX "RecipeInstance_userId_plannedFor_idx";
+
+-- DropIndex
+DROP INDEX "RecipeInstance_userId_status_idx";
+
+-- DropIndex
+DROP INDEX "RecipeTemplate_userId_archivedAt_idx";
+
+-- DropIndex
+DROP INDEX "RecipeTemplate_userId_idx";
+
+-- CreateIndex
+CREATE INDEX "RecipeInstance_userId_status_createdAt_idx" ON "RecipeInstance"("userId", "status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "RecipeInstance_templateId_status_idx" ON "RecipeInstance"("templateId", "status");
+
+-- CreateIndex
+CREATE INDEX "RecipeTemplate_userId_archivedAt_createdAt_idx" ON "RecipeTemplate"("userId", "archivedAt", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,36 +10,48 @@ datasource db {
   provider = "postgresql"
 }
 
-model Recipe {
-  id            String        @id @default(cuid())
-  userId        String
-  name          String        @db.VarChar(100)
-  servings      Int
-  ingredients   String[]
-  instructions  String        @db.VarChar(10000)
-  duration      Int?          // duration in minutes
-  difficulty    Int?          // scale: 1 (easy) to 10 (hard)
-  isFavorite    Boolean       @default(false)
-  createdAt     DateTime      @default(now())
-  plannedMeals  PlannedMeal[]
-  cookCount     Int           @default(0)
+model RecipeTemplate {
+  id           String    @id @default(cuid())
+  userId       String
+  name         String    @db.VarChar(100)
+  servings     Int
+  ingredients  String[]
+  instructions String    @db.VarChar(10000)
+  duration     Int? // duration in minutes
+  difficulty   Int? // scale: 1 (easy) to 10 (hard)
+  isFavorite   Boolean   @default(false)
+  archivedAt   DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  instances RecipeInstance[]
+
+  @@index([userId, archivedAt, createdAt])
 }
 
-model PlannedMeal {
-  id                   String   @id @default(cuid())
-  userId               String
-  recipe               Recipe   @relation(fields: [recipeId], references: [id], onDelete: Cascade)
-  recipeId             String
-  overrideName         String?  @db.VarChar(100)
-  overrideIngredients  String[] @default([])
-  overrideInstructions String?  @db.VarChar(10000)
-  overrideServings     Int?
-  overrideDuration     Int?
-  overrideDifficulty   Int?
+model RecipeInstance {
+  id         String         @id @default(cuid())
+  userId     String
+  template   RecipeTemplate @relation(fields: [templateId], references: [id], onDelete: Restrict)
+  templateId String
 
-  status               PlannedMealStatus @default(PLANNED)
-  createdAt            DateTime          @default(now())
-  cookedAt             DateTime?
+  name         String   @db.VarChar(100)
+  servings     Int
+  ingredients  String[]
+  instructions String   @db.VarChar(10000)
+  duration     Int?
+  difficulty   Int?
+
+  status      RecipeInstanceStatus @default(PLANNED)
+  plannedFor  DateTime?
+  startedAt   DateTime?
+  cookedAt    DateTime?
+  cancelledAt DateTime?
+  createdAt   DateTime             @default(now())
+  updatedAt   DateTime             @updatedAt
+
+  @@index([userId, status, createdAt])
+  @@index([templateId, status])
 }
 
 model UserDietaryPreferences {
@@ -59,7 +71,9 @@ model RateLimit {
   @@id([userId, day])
 }
 
-enum PlannedMealStatus {
+enum RecipeInstanceStatus {
   PLANNED
+  COOKING
   COOKED
+  CANCELLED
 }


### PR DESCRIPTION
## Summary
- Recipes are now **templates**; planned meals are **instances** that copy template content fields at creation time, so editing a template no longer mutates past planned or cooked meals.
- `cookCount` is derived from `COOKED` instances instead of being a stored column.
- Templates are soft-deleted via `archivedAt` to preserve instance history (instances reference templates with `onDelete: Restrict`).
- Dropped `override*` fields in favor of direct content fields on instances.
- Tightened DB indexes to match actual query/sort patterns (6 → 3 indexes).

## Notes
- App-level "planned meal" vocabulary is unchanged; this is a data-model refactor only.
- Two migrations included: model rename/restructure + index tightening.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint .` passes
- [ ] Deadlock integration tests require a live `DATABASE_URL` (vitest doesn't load `.env`); not run here, tracked separately

Made with [Cursor](https://cursor.com)